### PR TITLE
WDP210602-19 Add fades in new furniture

### DIFF
--- a/src/components/features/NewFurniture/NewFurniture.js
+++ b/src/components/features/NewFurniture/NewFurniture.js
@@ -8,19 +8,32 @@ class NewFurniture extends React.Component {
   state = {
     activePage: 0,
     activeCategory: 'bed',
+    isFading: false,
   };
 
   handlePageChange(newPage) {
-    this.setState({ activePage: newPage });
+    this.setState({ isFading: true });
+    setTimeout(() => {
+      this.setState({ activePage: newPage });
+    }, 500);
+    setTimeout(() => {
+      this.setState({ isFading: false });
+    }, 500);
   }
 
   handleCategoryChange(newCategory) {
-    this.setState({ activeCategory: newCategory });
+    this.setState({ isFading: true });
+    setTimeout(() => {
+      this.setState({ activeCategory: newCategory });
+    }, 500);
+    setTimeout(() => {
+      this.setState({ isFading: false });
+    }, 500);
   }
 
   render() {
     const { categories, products } = this.props;
-    const { activeCategory, activePage } = this.state;
+    const { activeCategory, activePage, isFading } = this.state;
 
     const categoryProducts = products.filter(item => item.category === activeCategory);
     const pagesCount = Math.ceil(categoryProducts.length / 8);
@@ -66,7 +79,9 @@ class NewFurniture extends React.Component {
               </div>
             </div>
           </div>
-          <div className='row'>
+          <div
+            className={'row' + (isFading ? ' ' + styles.fadeout : ' ' + styles.fadein)}
+          >
             {categoryProducts.slice(activePage * 8, (activePage + 1) * 8).map(item => (
               <div key={item.id} className='col-3'>
                 <ProductBox {...item} />

--- a/src/components/features/NewFurniture/NewFurniture.module.css
+++ b/src/components/features/NewFurniture/NewFurniture.module.css
@@ -1,0 +1,107 @@
+.root .panelBar {
+  margin-bottom: 30px;
+  position: relative;
+}
+
+.root .panelBar :global(.row) > * {
+  border-bottom: 4px solid #e2e2e2;
+}
+
+.root .panelBar .heading {
+  position: relative;
+}
+
+.root .panelBar .heading h3 {
+  color: #d58e32;
+  text-transform: uppercase;
+  font-size: 20px;
+  line-height: 38px;
+  margin: 0;
+  letter-spacing: 1px;
+}
+
+.root .panelBar .heading::before {
+  content: "";
+  position: absolute;
+  bottom: -4px;
+  left: 0;
+  width: 45px;
+  border-bottom: 4px solid #d58e32;
+}
+
+.root .panelBar .menu {
+  text-align: center;
+}
+
+.root .panelBar .menu ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.root .panelBar .menu ul li {
+  display: inline-block;
+  margin: 0 0.5rem;
+  font-weight: 600;
+}
+
+.root .panelBar .menu ul li a {
+  color: #2a2a2a;
+  position: relative;
+  text-decoration: none;
+  font-size: 18px;
+  display: block;
+}
+
+.root .panelBar .menu ul li a.active::before, .root .panelBar .menu ul li a:hover::before {
+  content: "";
+  position: absolute;
+  bottom: -4px;
+  left: 0;
+  width: 100%;
+  border-bottom: 4px solid #d58e32;
+}
+
+.root .panelBar .dots {
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+
+.root .panelBar .dots ul {
+  margin: 0;
+  padding: 0 0 0 1rem;
+  list-style: none;
+  background-color: #ffffff;
+  -webkit-transform: translateY(15px);
+          transform: translateY(15px);
+}
+
+.root .panelBar .dots ul li {
+  display: inline-block;
+  margin-left: 0.5rem;
+}
+
+.root .panelBar .dots ul li a {
+  display: block;
+  width: 13px;
+  height: 13px;
+  border-radius: 6px;
+  background-color: #e1e1e1;
+  font-size: 0;
+}
+
+.root .panelBar .dots ul li a.active, .root .panelBar .dots ul li a:hover {
+  background-color: #d58e32;
+}
+
+.root .fadeout {
+  opacity: 0;
+  -webkit-transition: 0.6s;
+  transition: 0.6s;
+}
+
+.root .fadein {
+  -webkit-transition: 0.6s;
+  transition: 0.6s;
+}

--- a/src/components/features/NewFurniture/NewFurniture.module.scss
+++ b/src/components/features/NewFurniture/NewFurniture.module.scss
@@ -98,4 +98,13 @@
       }
     }
   }
+
+  .fadeout {
+    opacity: 0;
+    transition: 0.6s;
+  }
+
+  .fadein {
+    transition: 0.6s;
+  }
 }


### PR DESCRIPTION
*WDP210602-19* 

In New Furniture section's categories ("bed", "dining" etc.) it is possible to change the set of visible products by clicking on categories or active dots. Client's request was to have an animation of switching between tabs and pages.

What was done:
- a method has been added in NewFurniture component that causes smooth animated transitions between categories, as well as between pages of a given category - dots pagination, 
- setTimeout function (delay) has been applied,
- in NewFurniture styles have been added fade in and fade out classes which properties are handling smooth transition in 0.6s,
- the work results in smooth fading transitions between tabs and categories' pages.